### PR TITLE
Remove rule excluding auth0 sample configuraiton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,3 @@ config.json
 data.json
 *.env
 dist
-auth0-variables.js


### PR DESCRIPTION
This .gitignore rule has no real effect and should be
removed after:
db4dbc13d45a430e34ac91110fafe383d24ba2d8

The file under rule is arleady tracked by index:

```bash
git check-ignore auth0-variables.js --no-index
```

Thanks!