### PR TITLE
Introduce local development server

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,23 @@ You can read more about Passwordless Authentication on our [Doc's Site](https://
 
 1. Create an auth0-variables.js file with your Auth0 credentials. You can use auth0-variables.sample.js as a template. You can get the clientId and domain from the [Auth0 Dashboard](https://manage.auth0.com).
 2. In your App's configuration on the [Auth0 Dashboard](https://manage.auth0.com), add `http://localhost:3000` to the **Allowed Origins (CORS)** list in order for the one time code samples to work, and add `http://localhost:3000/custom-magic-link.html, http://localhost:3000/lock-magic-link.html` to the **Allowed Callback URLs** list for the magic link samples to function. 
-3. Initialize a web server in the samples folder. You can do it for instance with `serve`:
-	* Install node
-	* run `npm install -g serve`
-	* run `serve` in the project's folder to start a server
-4. Go to the [index page](http://localhost:3000) and select the scenario you want to try. 
+3. If you have [Node and NPM installed](https://nodejs.org/en/download/), initialize and start a web server provided with samples by running `npm install`
+followed by `npm start`:
+
+	```bash
+	> npm install
+	> npm start
+	...
+	> browser-sync start --server --files='*.html' --index='index.html' --no-ui
+
+	[BS] Access URLs:
+	----------------------------------
+	Local: http://localhost:3000
+	External: http://192.168.1.30:3000
+	----------------------------------
+	[BS] Serving files from: ./
+	[BS] Watching files...
+	```
 
 ## What is Auth0?
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "auth0-jquery-passwordless-sample",
+  "version": "1.0.0",
+  "description": "This set of samples shows how you can use passwordless authentication in your single page application. There are samples for both SMS and Email connections and both using the Auth0 Lock widget or a custom UI.",
+  "private": true,
+  "scripts": {
+    "start": "browser-sync start --server --files='*.html' --index='index.html' --no-ui",
+    "serve": "npm start"
+  },
+  "author": "Auth0",
+  "license": "MIT",
+  "devDependencies": {
+    "browser-sync": "^2.18.6"
+  }
+}


### PR DESCRIPTION
This commit provides users the quick way to run samples in a
way already mentioned in README.md:

- start a local server
- a web page should be opened ready to use samples starting
on the index page

This is achieved with help of NPM installed `browser-sync`
tool:
https://www.browsersync.io/

The tool is installed as local dependency using NPM and just
starts when using default NPM start command using the same
UX scenario as mentioned in changed README content

The `package.json` file is being added to repository content
as poart of this commit.

The user experience:
```bash
npm install
```
```bash
npm start

> auth0-jquery-passwordless-sample@1.0.0 start /Users/piotrblazejewicz/git/auth0-jquery-passwordless-sample
> browser-sync start --server --files='*.html' --index='index.html' --no-ui

[BS] Access URLs:
 ----------------------------------
    Local: http://localhost:3000
 External: http://192.168.1.30:3000
 ----------------------------------
[BS] Serving files from: ./
[BS] Watching files...
```

Thanks!